### PR TITLE
update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "peerDependencies": {
-    "fastify": "< 3.x",
-    "slonik": "< 25.x"
+    "fastify": "< 4.x",
+    "slonik": "< 28.x"
   },
   "peerDependenciesMeta": {
     "fastify": {


### PR DESCRIPTION
peer dependencies for fastify (`< 3.x`) and slonik (`< 25.x`) were inconsistent with the declared devDependencies for the same (`fastify: 4.0.3` and `slonik: 28.1.1`).